### PR TITLE
Resolve Open Sans Light CSS Issue

### DIFF
--- a/opensans.css
+++ b/opensans.css
@@ -42,7 +42,7 @@
 
 @font-face {
     font-family: 'opensans-light';
-    src: url('fonts/opensans-lightk.ttf') format('truetype');
+    src: url('fonts/opensans-light.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
This PR resolves the src reference to the open sans light font by removing the additional `k` added in the src property of the @font-face definition.